### PR TITLE
Refactored and generated score limit labels d3 way

### DIFF
--- a/gaugechart.js
+++ b/gaugechart.js
@@ -120,14 +120,15 @@ const drawGaugeChart = function (selector, width, score, slabData, isAnimated) {
         }
     ]
 
-    scoreLimits.forEach(function (l) {
-        g.append("text")
+    g.selectAll("text")
+        .data(scoreLimits)
+        .enter()
+        .append("text")
         .attr("class", scoreLimitClassName)
-        .attr("x", l.xLocation)
+        .attr("x", d => d.xLocation)
         .attr("text-anchor", "middle")
         .attr("dy", arcWidth * 2)
-        .text(l.label);
-    });
+        .text(d => d.label);
 
     // Circle-shaped pointer
     const rotatePointerWithSnapping = function(score) {


### PR DESCRIPTION
Previously, the score limits were generated in an amateur way. Now, it is generated the way d3 recommends i.e. by binding data to elements.