### PR TITLE
Removed redundant stroke-width in css

### DIFF
--- a/gaugechart.css
+++ b/gaugechart.css
@@ -33,8 +33,6 @@ svg.meter-gauge {
 @keyframes thickenArc {
     to {
         stroke-width: 1%; 
-    stroke-width: 1%;
-        stroke-width: 1%; 
     }
 }
 .meter-gauge .hidden {


### PR DESCRIPTION
Redundant `stroke-width` properties in css possibly due to merge issues. Fixed it.